### PR TITLE
English corrections to app text

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -10,7 +10,7 @@
 	<string name="reg_input_conf_title">Registration</string>
 	<string name="reg_input_conf_body">Please enter validation code</string>
 	<string name="gps_activate_gps_title">Activate GPS</string>
-    <string name="gps_activate_gps_body">Please turn on the GPS so proof of location could be established</string>
+    <string name="gps_activate_gps_body">Please turn on the GPS so proof of location can be established</string>
     <string name="gps_activate_gps_setting">Open GPS Settings</string>
 	
 	<string name="activation_code_template_eng">La\'Zooz app registration token: </string>
@@ -19,7 +19,7 @@
 	
 	<string name="recommendation_input_msg_title">Recommendation</string>
 	<string name="recommendation_input_msg_body">Please enter a personal recommendation note.</string>
-	<string name="recommendation_default">This is a link to social app I installed. This application is building a "ride sharing" network that will be owned by the community. After installing this App it will start mining Potential Zooz tokens for you while driving. When the network will be established those tokens will be used for moving. Check it out.</string>
+	<string name="recommendation_default">This is a link to social app I installed. This application builds a 'ride sharing' network which will be owned by the community. After you install this app it will start mining Potential Zooz tokens for you while you drive with your phone's GPS on. When the network will be established you can use these tokens to pay for movement. Check it out!</string>
 	<string name="recommendation_default_start">Hello there, </string>
 	<string name="invitation_sent">Invitation sent</string>
 	
@@ -68,12 +68,12 @@
     
     <string name="gps_message_no_gps_yes_net">Your GPS is off, please note that you will not be able to collect zoozs</string>
     <string name="gps_message_no_gps_no_net">Your GPS and your network location are turned off, please note that you will not be able to collect zoozs</string>
-    <string name="gps_message_no_gps_no_net_feature">Your GPS and your network location are turned off.You need to enable that for this feature</string>
+    <string name="gps_message_no_gps_no_net_feature">Your GPS and your network location are turned off. You need to enable that for this feature</string>
     <string name="gps_message_yes_gps_no_net">Your network location is disable. It is recommended to enable it for battery usage efficiency</string>
     
     <string name="splash_version_check_title">New Version</string>
-    <string name="splash_version_check_les_current">There is a new version of La\'Zooz, please update app from Google Play.</string>
-    <string name="splash_version_check_les_min">Your current version of La\'Zooz is not up to date. In order to proceed, please update app from Google Play.</string>
+    <string name="splash_version_check_les_current">There is a new version of La\'Zooz, please update the app from Google Play.</string>
+    <string name="splash_version_check_les_min">Your current version of La\'Zooz is not up to date. In order to proceed, please update the app from Google Play.</string>
     
     
     <string name="settings_category_mining">Mining</string>


### PR DESCRIPTION
Used active voice, simple present and 2nd person (you/your phone etc.)
where needed.
Corrected use of 'that' to 'which'
Added clarification that the app mines zoozs when GPS is on
